### PR TITLE
Adding github-link using updates to torture gem

### DIFF
--- a/lib/torture_helper.rb
+++ b/lib/torture_helper.rb
@@ -10,4 +10,25 @@ module TortureHelper
 
     Torture::Snippet.extract_from(file: file, root: root, marker: section, collapse: collapse, unindent: true)
   end
+
+  def github_link(component, section, collapse: "methods", file:nil)
+    config = current_page.data["torture"]
+    config = config[component]
+
+    file ||= config[:default_file]
+    root = config[:root] or raise "No root found for #{component}"
+
+    path_and_line = Torture::Snippet.extract_line_number_and_filename_from(file: file, root: root, marker: section)
+    path = path_and_line[:path].split('/').drop(2).join('/')
+    line = path_and_line[:line]
+    link = Torture::Snippet.build_github_link(github_user: 'trailblazer',
+                                               gem_name: "trailblazer-#{component}",
+                                               path: path,
+                                               line_number: line )
+    markdown_link = "[See code on Github](#{link})"
+  end
+
 end
+
+
+

--- a/source/includes/activity/_wiring_api.md.erb
+++ b/source/includes/activity/_wiring_api.md.erb
@@ -157,9 +157,12 @@ In this example, if a sign in request can't be handled via Omniauth (because the
 
 > Use the `Track()` helper to reference a track.
 
+
+
 ```ruby
 <%= snippet :activity, "track-ref", collapse: "methods", file: "docs/track_test.rb" %>
 ```
+> <%= github_link :activity, "track-ref", collapse: "methods", file: "docs/track_test.rb" %>
 
 Connecting tasks specifically to other tasks [via IDs](#activity-output-id) is the right choice if you "know" what will be the next step. However, often, you don't want to hard-wire steps to each other but place them on tracks, and let the activity take care of connecting the tasks in the right order.
 


### PR DESCRIPTION
Extra snippet to create a github link , with a usage example in wiring_api section. Based on this PR: https://github.com/apotonick/torture/pull/1  ( @apotonick - accept PR and pull first for this work)

Cheers, mate. Hope you are having fun in UK. 